### PR TITLE
Update range-slider.js

### DIFF
--- a/src/range-slider.js
+++ b/src/range-slider.js
@@ -80,7 +80,7 @@ export default class RangeSlider {
 
     generatePointPositions() {
         return this.allProps.values.map(value => {
-            let percentage = (value / this.allProps.max) * 100;
+            var percentage = ((value - _this2.allProps.min) / (_this2.allProps.max - _this2.allProps.min)) * 100;
             return Math.floor((percentage / 100) * this.container.offsetWidth);
         });
     }


### PR DESCRIPTION
slider badly handles negative numbers, producing wrong point positions. the function generatePointPositions need a slight adjustment:  var percentage = ((value - _this2.allProps.min) / (_this2.allProps.max - _this2.allProps.min)) * 100;

instead of current:
var percentage = (value/_this2.allProps.max)) * 100;